### PR TITLE
fix: add 'use-client' directive on imported lib to address error

### DIFF
--- a/libs/my-app/feature-main/src/lib/my-app-feature-main.tsx
+++ b/libs/my-app/feature-main/src/lib/my-app-feature-main.tsx
@@ -1,3 +1,4 @@
+'use client';
 import styles from './my-app-feature-main.module.css';
 
 /* eslint-disable-next-line */


### PR DESCRIPTION
fix: add 'use-client' directive on imported lib to address createContext called in a React Server Component error